### PR TITLE
Fix report line of first offender for strictOrderOfNthCalledWith

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.4.2 (2024-09-19)
+
+- Fix report node to be first offender for `strictOrderOfNthCalledWith` option
+
 ## 1.4.1 (2024-09-18)
 
 - Fixes an issue where more than one out of order `toHaveBeenNthCalledWith`, and `toHaveBeenCalledTimes` out of order wouldn't get properly fixed.

--- a/lib/rules/helpers.js
+++ b/lib/rules/helpers.js
@@ -1,4 +1,4 @@
-const { toHaveBeenCalledTimes, toHaveBeenNthCalledWith } = require('./constants')
+const { toHaveBeenCalledTimes } = require('./constants')
 
 
 const getPreviousNode = (node, index = 1) => {
@@ -28,69 +28,19 @@ const getArgsOfExpectCall = (node) => {
 };
 
 const getNumberOfTimesCalled = (node) => {
+	if (node?.expression?.callee?.property?.name !== 'toHaveBeenCalledTimes') {
+		throw new Error('Passing in a node that does not contain `toHaveBeenCalledTimes`');
+	}
+
 	return node?.expression.arguments[0].value;
 };
 
 const getNumberOfNthCalledWith = (node) => {
+	if (node?.expression?.callee?.property.name !== 'toHaveBeenNthCalledWith') {
+		throw new Error('Passing in a node that does not contain `toHaveBeenCalledWith`');
+	}
+
 	return node?.expression.arguments[0].value;
-};
-
-/**
- * Returns if nthCalled nodes are in order, and if not returns which node is the offender
- * @param node	this is expected to be called with the first nthCalledWith(1, ANYTHING), we check back but we traverse ahead
- * @return {Object}
- */
-const getNodeNthCalledWithIsOrdered = (node) => {
-	const returnObj = {
-		isOrdered: false,
-		offendingNode: null,
-	};
-
-	// initial check if there are any before that would instantly fail this
-	// before we consider everything good, let's check the previous node to see if it was a `toHaveBeenNthCalledWith`.
-	const previousNode = getPreviousNode(node);
-	const previousNodePropertyName = getNodePropertyName(previousNode);
-
-	if (previousNodePropertyName === toHaveBeenNthCalledWith) {
-		returnObj.offendingNode = previousNode;
-		return returnObj;
-	}
-
-	let loop = true;
-	// this should be 1, and we should only call with the first one but let's fail here hard if not.
-	// this would be a problem with this rule and not the person's code
-	const nodeNthCalledWith = getNumberOfNthCalledWith(node);
-
-	if (nodeNthCalledWith !== 1) {
-		// it does not make sense to call this function on every node that contains `NthCalledWith`.  Call it on the first and get your answer
-		throw new Error('this should only ever be called with the first node NthCalledWith `1` so we traverse ahead');
-	}
-
-	let nthCalledWith = 2;
-
-	while (loop) {
-		const currentNode = getNextNode(node, nthCalledWith);
-		const nextNodePropertyName = getNodePropertyName(currentNode);
-
-		if (nextNodePropertyName === toHaveBeenNthCalledWith) {
-			const nextNodeNthCalledWith = getNumberOfNthCalledWith(currentNode);
-
-			if (nextNodeNthCalledWith !== nthCalledWith) {
-				returnObj.offendingNode = currentNode;
-				loop = false;
-			} else {
-				nthCalledWith++;
-			}
-		} else if (nextNodePropertyName === toHaveBeenCalledTimes) {
-			returnObj.isOrdered = true;
-			loop = false;
-		} else {
-			returnObj.offendingNode = node;
-			loop = false;
-		}
-	}
-
-	return returnObj;
 };
 
 /**
@@ -157,13 +107,23 @@ const getErrorMessageObject = (options, fallbackMessageId) => {
 	return customReportMessage.message ? customReportMessage : generalMessages;
 };
 
+function arrIdentical(a1, a2) {
+	// Tim Down: http://stackoverflow.com/a/7837725/308645
+	var i = a1.length;
+	if (i != a2.length) return false;
+	while (i--) {
+		if (a1[i] !== a2[i]) return false;
+	}
+	return true;
+}
+
 module.exports = {
+	arrIdentical,
 	getErrorMessageObject,
 	getEventuallyCalledTimesExists,
 	getEventuallyCalledTimesExistsBefore,
 	getArgsOfExpectCall,
 	getNextNode,
-	getNodeNthCalledWithIsOrdered,
 	getNumberOfNthCalledWith,
 	getNumberOfTimesCalled,
 	getNodePropertyName,

--- a/lib/rules/jest.js
+++ b/lib/rules/jest.js
@@ -1,11 +1,11 @@
 const {
+	arrIdentical,
 	getErrorMessageObject,
 	getEventuallyCalledTimesExists,
 	getEventuallyCalledTimesExistsBefore,
 	getArgsOfExpectCall,
 	getNodePropertyName,
 	getNextNode,
-	getNodeNthCalledWithIsOrdered,
 	getNumberOfNthCalledWith,
 	getNumberOfTimesCalled,
 	getPreviousNode,
@@ -80,21 +80,46 @@ module.exports = {
 					}
 
 					if (options?.toHaveBeenNthCalledWith?.strictOrderOfNthCalledWith) {
-						const numberNthCalledWith = getNumberOfNthCalledWith(node);
+						// we start at the very start of the list and sort them
+						if (getNodePropertyName(previousNode) !== toHaveBeenNthCalledWith) {
+							const nthCalledWithOrder = [];
+							let finishedGettingOrder = false;
+							let curNode = node;
+							while (!finishedGettingOrder) {
+								const nthCalledWithNumber = getNumberOfNthCalledWith(curNode);
+								nthCalledWithOrder.push(nthCalledWithNumber);
+								const tmpNextNode = getNextNode(curNode);
 
-						if (numberNthCalledWith === 1) {
-							const { isOrdered, offendingNode } = getNodeNthCalledWithIsOrdered(node);
-
-							if (!isOrdered && !offendingNode) {
-								throw new Error('Need to report an offending node with the report. This is not an error with your code, but an error with the ESLint plugin `eslint-plugin-calledwith-calledtimes`');
+								if (tmpNextNode && getNodePropertyName(tmpNextNode) === toHaveBeenNthCalledWith) {
+									curNode = getNextNode(curNode);
+								} else {
+									finishedGettingOrder = true;
+								}
 							}
 
-							if (!isOrdered) {
-								return context.report({
-									node: offendingNode,
-									...getErrorMessageObject(options, 'outOfOrderNthCalledWith'),
-								});
+							const nthCalledWithOrderSorted = [...nthCalledWithOrder].sort((a, b) => a - b);
+
+							if (arrIdentical(nthCalledWithOrder, nthCalledWithOrderSorted)) {
+								return;
 							}
+
+							const nodeIndexToReport = nthCalledWithOrder.find((i, index) => i < nthCalledWithOrder[index + 1]);
+
+							return context.report({
+								node: getNextNode(node, nodeIndexToReport),
+								fix(fixer) {
+									const fixes = [];
+									for (let i = 0; i < nthCalledWithOrder.length; i++) {
+										const posInSortedArray = nthCalledWithOrderSorted.indexOf(nthCalledWithOrder[i]);
+										const tmpCurNode = getNextNode(node, i);
+										const nodeText = context.sourceCode.getText(tmpCurNode);
+										const nodeToReplace = getNextNode(node, posInSortedArray);
+										fixes.push(fixer.remove(tmpCurNode), fixer.insertTextAfter(nodeToReplace, nodeText));
+									}
+									return fixes;
+								},
+								...getErrorMessageObject(context.options, 'outOfOrderNthCalledWith'),
+							});
 						}
 					}
 				}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "eslint-plugin-calledwith-calledtimes",
-	"version": "1.4.1",
+	"version": "1.4.2",
 	"description": "suggest using toHaveBeenCalledTimes when using toHaveBeenCalledWith",
 	"keywords": [
 		"eslint",

--- a/tests/lib/rules/toHaveBeenNthCalledWith.js
+++ b/tests/lib/rules/toHaveBeenNthCalledWith.js
@@ -191,12 +191,13 @@ ruleTester.run('strictNumberOfCalledWithMatchesCalledTimes', rules.rules['jest']
 			code: `
 				expect(foo).toHaveBeenCalled()
 				expect(foo).toHaveBeenNthCalledWith(2, 'bar2')
-				expect(foo).toHaveBeenCalledTimes(2)
+				expect(foo).toHaveBeenNthCalledWith(3, 'bar2')
+				expect(foo).toHaveBeenCalledTimes(3)
 			`,
 			errors: [{
 				message: messages.missingExpectedToHaveBeenNthCalledWith,
 				type: 'ExpressionStatement',
-				line: 4,
+				line: 5,
 				column: 5,
 			}],
 		},
@@ -232,6 +233,7 @@ ruleTester.run('strictOrderOfNthCalledWith', rules.rules['jest'], {
 			code: `
 				expect(foo).toHaveBeenNthCalledWith(1, 'bar')
 				expect(foo).toHaveBeenNthCalledWith(3, 'bar2')
+				expect(foo).toHaveBeenNthCalledWith(8, 'bar2')
 				expect(foo).toHaveBeenCalledTimes(3)
 			`,
 		},
@@ -253,7 +255,7 @@ ruleTester.run('strictOrderOfNthCalledWith', rules.rules['jest'], {
 	],
 	invalid: [
 		{
-			name: 'number of toHaveBeenNthCalledWith is not ordered when rule is set to true',
+			name: 'toHaveBeenNthCalledWith is not ordered when rule is set to true',
 			options: [
 				{
 					toHaveBeenNthCalledWith: {
@@ -263,13 +265,20 @@ ruleTester.run('strictOrderOfNthCalledWith', rules.rules['jest'], {
 			],
 			code: `
 				expect(foo).toHaveBeenNthCalledWith(2, 'bar')
+				expect(foo).toHaveBeenNthCalledWith(3, 'bar')
 				expect(foo).toHaveBeenNthCalledWith(1, 'bar')
-				expect(foo).toHaveBeenCalledTimes(2)
+				expect(foo).toHaveBeenCalledTimes(3)
+			`,
+			output: `
+				expect(foo).toHaveBeenNthCalledWith(1, 'bar')
+				expect(foo).toHaveBeenNthCalledWith(2, 'bar')
+				expect(foo).toHaveBeenNthCalledWith(3, 'bar')
+				expect(foo).toHaveBeenCalledTimes(3)
 			`,
 			errors: [{
 				message: messages.outOfOrderNthCalledWith,
 				type: 'ExpressionStatement',
-				line: 2,
+				line: 4,
 				column: 5,
 			}],
 		},
@@ -304,7 +313,7 @@ ruleTester.run('strictOrderOfNthCalledWith', rules.rules['jest'], {
 				{
 					message: messages.outOfOrderNthCalledWith,
 					type: 'ExpressionStatement',
-					line: 4,
+					line: 5,
 					column: 5,
 				}
 			],


### PR DESCRIPTION
Before it would report the line before the first offender, this changes it so that the first offender in the list is reported