### PR TITLE
Adds the ability to filter tests by test name

### DIFF
--- a/tests/lib/helpers.js
+++ b/tests/lib/helpers.js
@@ -1,8 +1,15 @@
-const INDIVIDUAL_TEST = process.env.INDIVIDUAL_TEST
 
-// if INDIVIDUAL_TEST is set with the test name it will only run that specific test
+// Pass in test names as an env var with delimiter `__`
+const FILTER_TESTS = process.env.FILTER_TESTS
+
+let filteredTestsSplit = []
+
+if (FILTER_TESTS) {
+	filteredTestsSplit = FILTER_TESTS.split('__')
+}
+
 function shouldRunTest(test) {
-	return test.name === INDIVIDUAL_TEST || INDIVIDUAL_TEST === undefined
+	return filteredTestsSplit.includes(test.name) || filteredTestsSplit.length === 0
 }
 
 module.exports = {

--- a/tests/lib/helpers.js
+++ b/tests/lib/helpers.js
@@ -1,0 +1,10 @@
+const INDIVIDUAL_TEST = process.env.INDIVIDUAL_TEST
+
+// if INDIVIDUAL_TEST is set with the test name it will only run that specific test
+function shouldRunTest(test) {
+	return test.name === INDIVIDUAL_TEST || INDIVIDUAL_TEST === undefined
+}
+
+module.exports = {
+	shouldRunTest
+}

--- a/tests/lib/rules/general.js
+++ b/tests/lib/rules/general.js
@@ -5,6 +5,8 @@ const { messages } = require('../../../lib/rules/constants');
 
 const ruleTester = new RuleTester();
 
+const { shouldRunTest } = require('../helpers')
+
 ruleTester.run('general', rules.rules['jest'], {
 	valid: [],
 	invalid: [
@@ -22,5 +24,5 @@ ruleTester.run('general', rules.rules['jest'], {
 				},
 			],
 		},
-	],
+	].filter(shouldRunTest),
 });

--- a/tests/lib/rules/toHaveBeenCalledWith.js
+++ b/tests/lib/rules/toHaveBeenCalledWith.js
@@ -5,6 +5,8 @@ const { messages } = require('../../../lib/rules/constants');
 
 const ruleTester = new RuleTester();
 
+const { shouldRunTest } = require('../helpers')
+
 ruleTester.run('toHaveBeenCalledWith', rules.rules['jest'], {
 	valid: [
 		{
@@ -16,7 +18,7 @@ ruleTester.run('toHaveBeenCalledWith', rules.rules['jest'], {
 				expect(foo).toHaveBeenCalledTimes(1)
 			`,
 		},
-	],
+	].filter(shouldRunTest),
 	invalid: [
 		{
 			name: 'toHaveBeenCalledTimes to be after toHaveBeenCalledWith (not correct node after)',
@@ -119,7 +121,7 @@ ruleTester.run('toHaveBeenCalledWith', rules.rules['jest'], {
 				},
 			],
 		},
-	],
+	].filter(shouldRunTest),
 });
 
 ruleTester.run('strictNumberOfCalledWithMatchesCalledTimes', rules.rules['jest'], {
@@ -157,7 +159,7 @@ ruleTester.run('strictNumberOfCalledWithMatchesCalledTimes', rules.rules['jest']
 				expect(foo).toHaveBeenCalledTimes(2)
 			`,
 		},
-	],
+	].filter(shouldRunTest),
 	invalid: [
 		{
 			name: "number of toHaveBeenCalledWith calls doesn't match number in toHaveBeenCalledTimes (calledTimes: number)",
@@ -201,5 +203,5 @@ ruleTester.run('strictNumberOfCalledWithMatchesCalledTimes', rules.rules['jest']
 				},
 			],
 		},
-	],
+	].filter(shouldRunTest),
 });

--- a/tests/lib/rules/toHaveBeenNthCalledWith.js
+++ b/tests/lib/rules/toHaveBeenNthCalledWith.js
@@ -5,6 +5,8 @@ const { messages } = require('../../../lib/rules/constants');
 
 const ruleTester = new RuleTester();
 
+const { shouldRunTest } = require('../helpers')
+
 ruleTester.run('toHaveBeenNthCalledWith', rules.rules['jest'], {
 	valid: [
 		{
@@ -14,7 +16,7 @@ ruleTester.run('toHaveBeenNthCalledWith', rules.rules['jest'], {
 				expect(foo).toHaveBeenCalledTimes(1)
 			`,
 		},
-	],
+	].filter(shouldRunTest),
 	invalid: [
 		{
 			name: 'toHaveBeenCalledTimes to be after toHaveBeenNthCalledWith (not correct node after)',
@@ -117,7 +119,7 @@ ruleTester.run('toHaveBeenNthCalledWith', rules.rules['jest'], {
 				},
 			],
 		},
-	],
+	].filter(shouldRunTest),
 });
 
 ruleTester.run('strictNumberOfCalledWithMatchesCalledTimes', rules.rules['jest'], {
@@ -155,7 +157,7 @@ ruleTester.run('strictNumberOfCalledWithMatchesCalledTimes', rules.rules['jest']
 				expect(foo).toHaveBeenCalledTimes(2)
 			`,
 		},
-	],
+	].filter(shouldRunTest),
 	invalid: [
 		{
 			name: "number of toHaveBeenNthCalledWith calls doesn't match number in toHaveBeenCalledTimes (calledTimes: number)",
@@ -225,7 +227,7 @@ ruleTester.run('strictNumberOfCalledWithMatchesCalledTimes', rules.rules['jest']
 				column: 5,
 			}],
 		},
-	],
+	].filter(shouldRunTest),
 });
 
 ruleTester.run('strictOrderOfNthCalledWith', rules.rules['jest'], {
@@ -282,7 +284,7 @@ ruleTester.run('strictOrderOfNthCalledWith', rules.rules['jest'], {
 				expect(foo).toHaveBeenCalledTimes(2)
 			`,
 		},
-	],
+	].filter(shouldRunTest),
 	invalid: [
 		{
 			name: 'toHaveBeenNthCalledWith is not ordered when rule is set to true',
@@ -356,5 +358,5 @@ ruleTester.run('strictOrderOfNthCalledWith', rules.rules['jest'], {
 				}
 			],
 		},
-	],
+	].filter(shouldRunTest),
 });


### PR DESCRIPTION
By setting an env var like so

```
FILTER_TESTS=toHaveBeenCalledTimes to be after toHaveBeenCalledWith (not correct node after)__number of toHaveBeenCalledWith calls doesn't match string in toHaveBeenCalledTimes (calledTimes: string)
```

individual tests can be run which will make it easier to develop and debug.